### PR TITLE
Allow bsonToMember to read a int instead of a long

### DIFF
--- a/source/mongoschema/package.d
+++ b/source/mongoschema/package.d
@@ -205,6 +205,11 @@ private T bsonToMember(T)(auto ref T member, Bson value)
 	}
 	else static if (__traits(compiles, { value.get!T(); }))
 	{ // Check if this can be passed
+		static if (is(T == long))
+		{ // If the output expects a long, but the data is a int, do .get!int
+			if (value.type == Bson.Type.int_)
+				return value.get!int();
+		}
 		return value.get!T();
 	}
 	else static if (!isBasicType!T)


### PR DESCRIPTION
Sometimes the data is stored as a int instead of a long. This should be allowed
to be read even though the struct expects a long. As int can be converted to
longs implicitly.